### PR TITLE
force Python 2.7 for cpp bindings

### DIFF
--- a/libpracmln/CMakeLists.txt
+++ b/libpracmln/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Warray-bounds -Wtype-limits -Wreturn-ty
 ##################
 
 ## System dependencies are found with CMake's conventions
-find_package(PythonLibs)
+find_package(PythonLibs 2.7 REQUIRED)
 
 if(NOT PYTHONLIBS_FOUND)
   message(ERROR "PythonLibs not found!")


### PR DESCRIPTION
- changed CMake to look for specific version(2.7) of Python. Needed when multiple versions of python are present. 