### PR TITLE
remove python3 syntax error (PEP8 E999)

### DIFF
--- a/python3/rosmln/scripts/mln_client.py
+++ b/python3/rosmln/scripts/mln_client.py
@@ -13,7 +13,7 @@ def mln_interface_client(query, config=None):
         mln_interface = rospy.ServiceProxy('mln_interface', MLNInterface)
         resp1 = mln_interface(query, config)
         return resp1.response
-    except rospy.ServiceException, e:
+    except rospy.ServiceException as e:
         print('Service call failed: %s'%e)
 
 

--- a/python3/rosmln/scripts/mln_client.py
+++ b/python3/rosmln/scripts/mln_client.py
@@ -21,7 +21,7 @@ def print_results(results):
     if not results.evidence:
         print('ERROR: Something went wrong...')
     else:
-        print results
+        print(results)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Corrected `except` statement to use Python3 `as` syntax.
Added parentheses around `print` statement.