### PR TITLE
Support both pip 9 and 10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,11 @@ import os
 from distutils.core import setup
 
 import _version
-import pip
-pip.main(['install', 'appdirs'])
+try:
+    from pip import main as pipmain
+except:
+    from pip._internal import main as pipmain
+pipmain(['install', 'appdirs'])
 # from setuptools.command import build_py
 
 


### PR DESCRIPTION
pip.main() was deprecated, a workaround was added that should work on both pip 9 and pip 10.

This caused problems for me, and it looks like others have run into the same issue: https://github.com/danielnyga/pracmln/issues/18